### PR TITLE
opt-in `pred` as type-guard in `getSIngleQueryParam` and `getMultipleQueryParams` 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,5 +19,8 @@ module.exports = {
     'jest'
   ],
   rules: {
+    // workaround: to allow overload. 
+    // TODO: re-write for typescript
+    'no-redeclare': 'off',
   }
 }

--- a/src/getters/getMultipleQueryParams.test.ts
+++ b/src/getters/getMultipleQueryParams.test.ts
@@ -25,5 +25,10 @@ describe("getMultipleQueryParams(key, pred)(query)", () => {
     expect(getMultipleQueryParams(query, "key", (s) => s === "a")).toEqual(
       result
     );
+
+    // strictly typed
+    expect<"a"[]>(
+      getMultipleQueryParams(query, "key", (s): s is "a" => s === "a")
+    ).toEqual(result);
   });
 });

--- a/src/getters/getMultipleQueryParams.ts
+++ b/src/getters/getMultipleQueryParams.ts
@@ -5,7 +5,6 @@ export function getMultipleQueryParams<T extends string>(
   key: string,
   pred?: (s: string) => s is T
 ): T[];
-// eslint-disable-next-line no-redeclare
 export function getMultipleQueryParams(
   query: ParsedUrlQuery,
   key: string,
@@ -37,7 +36,6 @@ export function getMultipleQueryParams(
  *
  * @param pred *optional*. the values *that fit this predicate* will be returned.
  */
-// eslint-disable-next-line no-redeclare
 export function getMultipleQueryParams(
   query: ParsedUrlQuery,
   key: string,

--- a/src/getters/getMultipleQueryParams.ts
+++ b/src/getters/getMultipleQueryParams.ts
@@ -1,5 +1,17 @@
 import { ParsedUrlQuery } from "../types/ParsedUrlQuery";
 
+export function getMultipleQueryParams<T extends string>(
+  query: ParsedUrlQuery,
+  key: string,
+  pred?: (s: string) => s is T
+): T[];
+// eslint-disable-next-line no-redeclare
+export function getMultipleQueryParams(
+  query: ParsedUrlQuery,
+  key: string,
+  pred?: (s: string) => boolean
+): string[];
+
 /**
  *
  * Returns an array of the values for the specified *key* in the query object.
@@ -25,11 +37,12 @@ import { ParsedUrlQuery } from "../types/ParsedUrlQuery";
  *
  * @param pred *optional*. the values *that fit this predicate* will be returned.
  */
-export const getMultipleQueryParams = (
+// eslint-disable-next-line no-redeclare
+export function getMultipleQueryParams(
   query: ParsedUrlQuery,
   key: string,
   pred: (s: string) => boolean = () => true
-): string[] => {
+): string[] {
   const _value = query[key];
 
   if (!_value) return [];
@@ -37,4 +50,4 @@ export const getMultipleQueryParams = (
   if (Array.isArray(_value)) return _value.filter(pred);
 
   return pred(_value) ? [_value] : [];
-};
+}

--- a/src/getters/getSingleQueryParam.test.ts
+++ b/src/getters/getSingleQueryParam.test.ts
@@ -23,5 +23,10 @@ describe("getSingleQueryParam(key, pred)(query)", () => {
     [{ key: ["b", "c"] }, undefined],
   ])('(%p, "key", (s) => s === "a") === %s', (query, result) => {
     expect(getSingleQueryParam(query, "key", (s) => s === "a")).toEqual(result);
+
+    // strictly typed as "a" | undefined
+    expect(
+      getSingleQueryParam(query, "key", (s): s is "a" => s === "a")
+    ).toEqual(result);
   });
 });

--- a/src/getters/getSingleQueryParam.test.ts
+++ b/src/getters/getSingleQueryParam.test.ts
@@ -24,8 +24,8 @@ describe("getSingleQueryParam(key, pred)(query)", () => {
   ])('(%p, "key", (s) => s === "a") === %s', (query, result) => {
     expect(getSingleQueryParam(query, "key", (s) => s === "a")).toEqual(result);
 
-    // strictly typed as "a" | undefined
-    expect(
+    // strictly typed
+    expect<"a" | undefined>(
       getSingleQueryParam(query, "key", (s): s is "a" => s === "a")
     ).toEqual(result);
   });

--- a/src/getters/getSingleQueryParam.ts
+++ b/src/getters/getSingleQueryParam.ts
@@ -5,7 +5,6 @@ export function getSingleQueryParam<T extends string>(
   key: string,
   pred?: (s: string) => s is T
 ): T | undefined;
-// eslint-disable-next-line no-redeclare
 export function getSingleQueryParam<T extends string>(
   query: ParsedUrlQuery,
   key: string,
@@ -36,7 +35,6 @@ export function getSingleQueryParam<T extends string>(
  *
  * @param pred *optional*. the first value *that fits this predicate* will be returned.
  */
-// eslint-disable-next-line no-redeclare
 export function getSingleQueryParam(
   query: ParsedUrlQuery,
   key: string,

--- a/src/getters/getSingleQueryParam.ts
+++ b/src/getters/getSingleQueryParam.ts
@@ -1,5 +1,17 @@
 import { ParsedUrlQuery } from "../types/ParsedUrlQuery";
 
+export function getSingleQueryParam<T extends string>(
+  query: ParsedUrlQuery,
+  key: string,
+  pred?: (s: string) => s is T
+): T | undefined;
+// eslint-disable-next-line no-redeclare
+export function getSingleQueryParam<T extends string>(
+  query: ParsedUrlQuery,
+  key: string,
+  pred?: (s: string) => boolean
+): T | undefined;
+
 /**
  * Returns the first value for the specified *key* in the query object.
  * If `pred` specified, returns the first value *that meets it*.
@@ -24,11 +36,12 @@ import { ParsedUrlQuery } from "../types/ParsedUrlQuery";
  *
  * @param pred *optional*. the first value *that fits this predicate* will be returned.
  */
-export const getSingleQueryParam = (
+// eslint-disable-next-line no-redeclare
+export function getSingleQueryParam(
   query: ParsedUrlQuery,
   key: string,
   pred: (s: string) => boolean = () => true
-): string | undefined => {
+): string | undefined {
   const _value = query[key];
 
   if (!_value) return undefined;
@@ -36,4 +49,4 @@ export const getSingleQueryParam = (
   if (Array.isArray(_value)) return _value.filter(pred)[0];
 
   return pred(_value) ? _value : undefined;
-};
+}


### PR DESCRIPTION
getSIngleQueryParam and getMultipleQueryParams 's `pred` parameter now can be type-guard predicate (e.g. `(s): s is "x" => s === "x"`) to narrow return type of these functions.