### PR TITLE
feat: `getSingleQueryParamCurried` を実装 - `getSingleQueryParam` の data-last カリー化バージョン

### DIFF
--- a/src/getters/getSingleQueryParamCurried.test.ts
+++ b/src/getters/getSingleQueryParamCurried.test.ts
@@ -1,0 +1,38 @@
+import { ParsedUrlQuery } from "../types/ParsedUrlQuery";
+import { getSingleQueryParam } from "./getSingleQueryParam";
+import { getSingleQueryParamCurried } from "./getSingleQueryParamCurried";
+
+describe("getSingleQueryParamCurried(key, pred)(query)", () => {
+  type Case = [query: ParsedUrlQuery];
+
+  it.each<Case>([[{ key: "a" }], [{ key: [] }], [{}]])(
+    '(%p, "key") matches non-curreid version\'s result',
+    (query) => {
+      const getKey = getSingleQueryParamCurried("key");
+      expect(getKey(query)).toEqual(getSingleQueryParam(query, "key"));
+    }
+  );
+
+  it.each<Case>([
+    [{ key: "a" }],
+    [{ key: ["a"] }],
+    [{ key: ["a", "b"] }],
+    [{ key: ["b", "a"] }],
+    [{}],
+    [{ key: "b" }],
+    [{ key: ["b"] }],
+    [{ key: ["b", "c"] }],
+  ])(
+    '("key", (s) => s === "a")(%p) matches non-curreid version\'s result',
+    (query) => {
+      const result = getSingleQueryParam(query, "key", (s) => s === "a");
+      const getKeyLoose = getSingleQueryParamCurried("key", (s) => s === "a");
+      expect(getKeyLoose(query)).toEqual(result);
+
+      // strictly typed
+      const isA = (s: string): s is "a" => s === "a";
+      const getKeyStrict = getSingleQueryParamCurried("key", isA);
+      expect<"a" | undefined>(getKeyStrict(query)).toEqual(result);
+    }
+  );
+});

--- a/src/getters/getSingleQueryParamCurried.ts
+++ b/src/getters/getSingleQueryParamCurried.ts
@@ -1,0 +1,28 @@
+import { ParsedUrlQuery } from "../types/ParsedUrlQuery";
+import { getSingleQueryParam } from "./getSingleQueryParam";
+
+export function getSingleQueryParamCurried<T extends string>(
+  key: string,
+  pred: (s: string) => s is T
+): (query: ParsedUrlQuery) => T | undefined;
+
+export function getSingleQueryParamCurried(
+  key: string,
+  pred?: (s: string) => boolean
+): (query: ParsedUrlQuery) => string | undefined;
+
+/**
+ * "data-last" Curried version of {@link getSingleQueryParam}.
+ *
+ * @example
+ * ```
+ * const isValidSortOrder = (input: string): input is "asc" | "desc" => input === "asc" || input === "desc"
+ * const getSingleSortOrder = getSingleQueryParamCurreid("order", isValidSortOrder)
+ * ```
+ */
+export function getSingleQueryParamCurried(
+  key: string,
+  pred?: (s: string) => boolean
+): (query: ParsedUrlQuery) => string | undefined {
+  return (query) => getSingleQueryParam(query, key, pred);
+}

--- a/src/getters/index.ts
+++ b/src/getters/index.ts
@@ -1,2 +1,3 @@
 export { getMultipleQueryParams } from "./getMultipleQueryParams";
 export { getSingleQueryParam } from "./getSingleQueryParam";
+export { getSingleQueryParamCurried } from "./getSingleQueryParamCurried";


### PR DESCRIPTION
getSingleQueryParam を data-last にカリー化したバージョンとして `getSingleQueryParamCurried` を追加した。