### PR TITLE
fix: incorrect return type because of missing explicit annotation: `resetQuery` and `setQueryParams`

### DIFF
--- a/src/mutators/resetQuery.ts
+++ b/src/mutators/resetQuery.ts
@@ -1,4 +1,4 @@
-import { queryMutation } from "./_internal/queryMutation";
+import { QueryMutation, queryMutation } from "./_internal/queryMutation";
 
 /**
  * Resets the query (into empty object).
@@ -33,7 +33,7 @@ export const resetQuery = (
       | (string | undefined | null | boolean | number)[]
       | undefined;
   } = {},
-) => {
+): QueryMutation => {
   const ignoredKeys = (() => {
     const { ignore } = options;
     if (!ignore) return [];

--- a/src/mutators/setQueryParams.ts
+++ b/src/mutators/setQueryParams.ts
@@ -1,4 +1,4 @@
-import { queryMutation } from "./_internal/queryMutation";
+import { QueryMutation, queryMutation } from "./_internal/queryMutation";
 
 /**
  * Sets values of query parameters.
@@ -36,7 +36,7 @@ import { queryMutation } from "./_internal/queryMutation";
  */
 export const setQueryParams = (
   params: Record<string, string | string[] | undefined | null | 0 | false>,
-) => {
+): QueryMutation => {
   return queryMutation((query) =>
     Object.entries(params).reduce(
       (acc, [key, value]) => ({


### PR DESCRIPTION
closes #92 

## before

Return type `QueryMutation` was not explicitly annotated in **source file**, so type was wrong (to be `any` for the users of this library)

```ts
// before

export const resetQuery: (options?: {
    ignore?: string | (string | undefined | null | boolean | number)[] | undefined;
}) => import("mutators/_internal/queryMutation").QueryMutation;

export const setQueryParams: (params: Record<string, string | string[] | undefined | null | 0 | false>) => import("mutators/_internal/queryMutation").QueryMutation;
```

## after

```ts
// after

export const resetQuery: (options?: {
    ignore?: string | (string | undefined | null | boolean | number)[] | undefined;
}) => QueryMutation;

export const setQueryParams: (params: Record<string, string | string[] | undefined | null | 0 | false>) => QueryMutation;
```

