### PR TITLE
fix(getSingleQueryParam): stop type violation by giving strict type param

### DIFF
--- a/src/getters/getSingleQueryParam.ts
+++ b/src/getters/getSingleQueryParam.ts
@@ -3,7 +3,7 @@ import { ParsedUrlQuery } from "../types/ParsedUrlQuery";
 export function getSingleQueryParam<T extends string>(
   query: ParsedUrlQuery,
   key: string,
-  pred?: (s: string) => s is T,
+  pred: (s: string) => s is T,
 ): T | undefined;
 export function getSingleQueryParam(
   query: ParsedUrlQuery,


### PR DESCRIPTION
## Before

Code below accidentally passes type check, which breaks type-safty. (Same doesn't go for `getSingleQueryParamCurreid`)

```ts
const a = getSingleQueryParam<"a" | "b">(query, "key");
// a is "a" | "b" | undefined, while not checked with predicate
```

## After

changed signature. You should rewrote the code like below;

```ts
const isAOrB = (s: string): s is "a" | "b" => s === "a" || s === "b";
const a = getSingleQueryParam(query, "key", isAOrB); 
  // a is "a" | "b" | undefined, depending on isAOrB's correctness
const b = getSingleQueryParam(query, "key");
  // a is string | undefined
```